### PR TITLE
Add xmpfilter (insert ruby execution results in file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ It's like rails.vim without the rails ([more](http://www.vim.org/scripts/script.
 Use the repeat command (.) with supported plugins ([more](http://www.vim.org/scripts/script.php?script_id=2136))
 
 
+## ruby-xmpfilter
+
+Helper for ruby's xmpfilter ([more](https://github.com/t9md/vim-ruby-xmpfilter))
+
+Annotate ruby code with the result of running it, Ruby Tapas style. Press ,X to
+append a '# =>' to a line, then ,x to execute the file and insert all results.
+
+**Important:** You need to install the `rcodetools` gem for this to work.
+
+
 ## speeddating
 Fix up C-a and C-x when dealing with dates. ([more](https://github.com/tpope/vim-speeddating))
 

--- a/vimrc
+++ b/vimrc
@@ -35,6 +35,7 @@ Bundle 'scrooloose/nerdcommenter'
 Bundle 'scrooloose/nerdtree'
 Bundle 'scrooloose/syntastic'
 Bundle 'sjl/gundo.vim'
+Bundle 't9md/vim-ruby-xmpfilter'
 Bundle 'tpope/vim-abolish'
 Bundle 'tpope/vim-endwise'
 Bundle 'tpope/vim-haml'
@@ -503,6 +504,15 @@ let g:vroom_write_all = 1
 let g:vroom_cucumber_path = 'cucumber '
 let g:vroom_map_keys = 0
 
+" xmp-filter mappings
+autocmd FileType ruby nmap <buffer> <Leader>X <Plug>(xmpfilter-mark)
+autocmd FileType ruby xmap <buffer> <Leader>X <Plug>(xmpfilter-mark)
+autocmd FileType ruby imap <buffer> <Leader>X <Plug>(xmpfilter-mark)
+
+autocmd FileType ruby nmap <buffer> <Leader>x <Plug>(xmpfilter-run)
+autocmd FileType ruby xmap <buffer> <Leader>x <Plug>(xmpfilter-run)
+autocmd FileType ruby imap <buffer> <Leader>x <Plug>(xmpfilter-run)
+
 " Disable Markdown folding
 let g:vim_markdown_folding_disabled=1
 
@@ -511,5 +521,5 @@ let g:vim_markdown_folding_disabled=1
 "  Keep this last to make sure local config overrides global!
 " ----------------------------------------------
 if filereadable(expand("~/.vimrc.local"))
-  source ~/.vimrc.local
+source ~/.vimrc.local
 endif


### PR DESCRIPTION
Turns out this was only ever in my branch.
- Install the `rcodetools` gem
- `,X` to insert a `#=>` on the current line
- `,x` to run and insert output
