### PR TITLE
Map comma as leader in all modes

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -104,8 +104,8 @@ let mapleader = " "
 
 " Comma has been the leader key for so long, emulate it being the leader still
 " for the sake of muscle memory
-nmap , <leader>
-nmap ,, <leader><leader>
+map , <leader>
+map ,, <leader><leader>
 
 
 " Set our primary colorscheme. Override this in ~/.vim.local if you want.


### PR DESCRIPTION
Right now the old leader compatibility only works in normal mode. This
is a pain when trying to comment out multiple lines with ,c<space>.

This commit makes the old leader compatibility work in all modes.